### PR TITLE
full-text search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: python
 cache: pip
 python:
@@ -11,6 +12,10 @@ env:
 services:
   - postgresql
   - elasticsearch
+before_install:
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.deb
+  - sudo dpkg -i --force-confnew elasticsearch-6.2.4.deb
+  - sudo service elasticsearch restart
 # command to install dependencies
 install: "make"
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ env:
   global:
     - PIPENV_IGNORE_VIRTUALENVS=1
     - TEST_DATABASE_URI="postgresql://postgres@localhost/travis_ci_test"
+    - ELASTICSEARCH_URL="http://localhost:9200"
 services:
   - postgresql
+  - elasticsearch
 # command to install dependencies
 install: "make"
 # command to run tests
 before_script:
+  - sleep 10  # allow Elasticsearch to initialize
   - psql -c 'create database travis_ci_test;' -U postgres
   - pipenv run python -m tests.data.setup_testdb
 script:

--- a/Pipfile
+++ b/Pipfile
@@ -4,18 +4,18 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-alembic = "*"
-"psycopg2" = "*"
-SQLAlchemy = "*"
-flask = "*"
-flask-sqlalchemy = "*"
-flask-migrate = "*"
+alembic = "~=0.9"
+"psycopg2" = "~=2.7"
+SQLAlchemy = "~=1.2"
+flask = "~=1.0"
+flask-sqlalchemy = "~=2.3"
+flask-migrate = "~=2.1"
 "e1839a8" = {path = ".", editable = true}
-python-dotenv = "*"
-elasticsearch = "*"
+python-dotenv = "~=0.8"
+elasticsearch = "~=6.2"
 
 [dev-packages]
-pylint = "*"
+pylint = "~=1.9"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ flask-sqlalchemy = "*"
 flask-migrate = "*"
 "e1839a8" = {path = ".", editable = true}
 python-dotenv = "*"
+elasticsearch = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2a54b5d5c37d00253f821747d9af82653b06b9682c892d05d0e06084d44965de"
+            "sha256": "bdd9947c002106e7a74f1c1c0892a089cac0939e7798fae76a377342f82721f4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,13 +34,21 @@
             "editable": true,
             "path": "."
         },
-        "flask": {
+        "elasticsearch": {
             "hashes": [
-                "sha256:7fab1062d11dd0038434e790d18c5b9133fd9e6b7257d707c4578ccc1e38b67c",
-                "sha256:b1883637bbee4dc7bc98d900792d0a304d609fce0f5bd9ca91d1b6457e5918dd"
+                "sha256:503c498234dd572896e563386181d7cb966ab3db68b0b132a26c5dabfd5dde24",
+                "sha256:b106fa3e01750376a42f8a9882bd84d630fda58c7aba38b4fec797d11c0bd0a2"
             ],
             "index": "pypi",
-            "version": "==1.0"
+            "version": "==6.2.0"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
+                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+            ],
+            "index": "pypi",
+            "version": "==1.0.2"
         },
         "flask-migrate": {
             "hashes": [
@@ -118,10 +126,10 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df",
-                "sha256:9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e"
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
             ],
-            "version": "==2.7.2"
+            "version": "==2.7.3"
         },
         "python-dotenv": {
             "hashes": [
@@ -151,6 +159,13 @@
             "index": "pypi",
             "version": "==1.2.7"
         },
+        "urllib3": {
+            "hashes": [
+                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
+                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+            ],
+            "version": "==1.22"
+        },
         "werkzeug": {
             "hashes": [
                 "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
@@ -162,10 +177,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:35cfae47aac19c7b407b7095410e895e836f2285ccf1220336afba744cc4c5f2",
-                "sha256:38186e481b65877fd8b1f9acc33e922109e983eb7b6e487bd4c71002134ad331"
+                "sha256:032f6e09161e96f417ea7fad46d3fac7a9019c775f202182c22df0e4f714cb1c",
+                "sha256:dea42ae6e0b789b543f728ddae7ddb6740ba33a49fb52c4a4d9cb7bb4aa6ec09"
             ],
-            "version": "==1.6.3"
+            "version": "==1.6.4"
         },
         "isort": {
             "hashes": [
@@ -218,11 +233,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:0b7e6b5d9f1d4e0b554b5d948f14ed7969e8cdf9a0120853e6e5af60813b18ab",
-                "sha256:34738a82ab33cbd3bb6cd4cef823dbcabdd2b6b48a4e3a3054a2bbbf0c712be9"
+                "sha256:b719c86a7395ea0c0ec8030c2a7a2b4fad573ee50460f9948fabb1811d72094f",
+                "sha256:cf1be367296e9e534a5cb420186ce99f63f17c2b855fcb4321a3e20ce51502cd"
             ],
             "index": "pypi",
-            "version": "==1.8.4"
+            "version": "==1.9.0"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ install project dependencies:
 
 create `.env` with commands or run manually:
 
-    export DATABASE_URI=<dialect://user:password@host/dbname>
+    export DATABASE_URI=<postgresql://user:password@host/dbname>
     export FLASK_APP=api
 
     # enable development environment with debug mode
     export FLASK_ENV=development
+
+    # enable Elasticsearch
+    export ELASTICSEARCH_URL="http://localhost:9200"
 
 download corpus data and set up the database:
 

--- a/api/factory.py
+++ b/api/factory.py
@@ -1,7 +1,9 @@
+from elasticsearch import Elasticsearch
 from flask import Flask
 from werkzeug.utils import find_modules, import_string
 
 from api import fdb, migrate # pylint: disable=cyclic-import
+from db.search import ESClient
 
 
 def create_app(config):
@@ -11,6 +13,7 @@ def create_app(config):
     fdb.init_app(app)
     migrate.init_app(app, fdb)
 
+    configure_elasticsearch(app)
     register_blueprints(app)
 
     return app
@@ -26,3 +29,10 @@ def register_blueprints(app):
         if hasattr(mod, 'bp'):
             app.register_blueprint(mod.bp)
     return None
+
+
+def configure_elasticsearch(app):
+    es_client = Elasticsearch(app.config['ELASTICSEARCH_URL']) \
+        if app.config['ELASTICSEARCH_URL'] else None
+    es_settings = app.config['ELASTICSEARCH_SETTINGS']
+    app.elasticsearch = ESClient(es_client, es_settings)

--- a/config.py
+++ b/config.py
@@ -11,8 +11,11 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     DEBUG = False
     TESTING = False
+    ELASTICSEARCH_URL = os.getenv('ELASTICSEARCH_URL')
+    ELASTICSEARCH_SETTINGS = '/home/iiu/python/populate_db/db/mapping.json'
 
 
 class TestingConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = os.getenv('TEST_DATABASE_URI', 'sqlite://')  # Use SQLite as fallback
+    ELASTICSEARCH_URL = None

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import load_dotenv
 
+APP_DIR = os.path.abspath(os.path.dirname(__file__))
 API_BASE_PATH = '/api'
 load_dotenv('.env')
 
@@ -12,7 +13,7 @@ class Config:
     DEBUG = False
     TESTING = False
     ELASTICSEARCH_URL = os.getenv('ELASTICSEARCH_URL')
-    ELASTICSEARCH_SETTINGS = '/home/iiu/python/populate_db/db/mapping.json'
+    ELASTICSEARCH_SETTINGS = os.path.join(APP_DIR, 'db/search/mapping.json')
 
 
 class TestingConfig(Config):

--- a/db/models.py
+++ b/db/models.py
@@ -47,6 +47,7 @@ movies_genres = Table(
 
 
 class Movie(Base):
+    __searchable__ = ['title']
     __tablename__ = 'movies'
     id = Column(String, primary_key=True)
 

--- a/db/search/__init__.py
+++ b/db/search/__init__.py
@@ -1,0 +1,1 @@
+from .client import ESClient

--- a/db/search/client.py
+++ b/db/search/client.py
@@ -1,0 +1,72 @@
+import json
+from sqlalchemy import case
+from elasticsearch.helpers import bulk
+
+
+class ESClient:
+    def __init__(self, client, settings):
+        self.client = client
+        self.settings = self._load_settings(settings)
+
+    def _load_settings(self, settings_json):
+        with open(settings_json) as f:
+            return json.load(f)
+
+    def create_index(self, model):
+        self.client.indices.create(index=model.__tablename__, body=self.settings)
+
+    def query_index(self, index, query, page, per_page):
+        if self.client is None:
+            return [], 0
+        body = {
+            'query': {
+                'multi_match': {
+                    'query': query,
+                    'fields': ['*']
+                }
+            },
+            'from': (page - 1) * per_page,
+            'size': per_page
+        }
+        search = self.client.search(
+            index=index,
+            doc_type=index,
+            body=body
+        )
+        print(search)
+        ids = [hit['_id'] for hit in search['hits']['hits']]
+        return ids, search['hits']['total']
+
+    def search(self, model, query, page, per_page):
+        ids, total = self.query_index(model.__tablename__, query, page, per_page)
+        if total == 0:
+            return ids, total
+        # Get objects from returned ids and enforce the same order as the ES query
+        whens = {id: i for i, id in enumerate(ids)}
+        return model.query.filter(model.id.in_(ids)).order_by(case(whens, value=model.id)), total
+
+    def bulk_add_to_index(self, model):
+        if self.client is None:
+            return
+        index = model.__tablename__
+        docs_gen = (
+            {
+                '_index': index,
+                '_type' : index,
+                '_id'   : obj.id,
+                '_source': ESClient.preprocess_obj(obj),
+            }
+            for obj in model.query
+        )
+        bulk(self.client, docs_gen)
+
+    def build_search_index(self, model):
+        self.create_index(model)
+        self.bulk_add_to_index(model)
+
+    @staticmethod
+    def preprocess_obj(obj):
+        data = {}
+        for field in obj.__searchable__:
+            data[field] = getattr(obj, field)
+        return data

--- a/db/search/client.py
+++ b/db/search/client.py
@@ -15,6 +15,9 @@ class ESClient:
     def create_index(self, model):
         self.client.indices.create(index=model.__tablename__, body=self.settings)
 
+    def delete_index(self, model):
+        self.client.indices.delete(index=model.__tablename__)
+
     def query_index(self, index, query, page, per_page):
         if self.client is None:
             return [], 0

--- a/db/search/mapping.json
+++ b/db/search/mapping.json
@@ -2,14 +2,14 @@
   "settings": {
     "analysis": {
       "analyzer": {
-        "ngram_analyzer": {
+        "edge_ngram_analyzer": {
           "type": "custom",
-          "tokenizer": "ngram_tokenizer"
+          "tokenizer": "edge_ngram_tokenizer"
         }
       },
       "tokenizer": {
-        "ngram_tokenizer": {
-          "type": "ngram",
+        "edge_ngram_tokenizer": {
+          "type": "edge_ngram",
           "min_gram": 3,
           "max_gram": 3,
           "token_chars": [
@@ -24,7 +24,7 @@
   "mappings": {
     "movies": {
       "properties": {
-        "title": {"type": "text", "analyzer": "ngram_analyzer"}
+        "title": {"type": "text", "analyzer": "edge_ngram_analyzer"}
       }
     }
   }

--- a/db/search/mapping.json
+++ b/db/search/mapping.json
@@ -1,0 +1,31 @@
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "ngram_tokenizer"
+        }
+      },
+      "tokenizer": {
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 3,
+          "max_gram": 3,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation"
+          ]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "movies": {
+      "properties": {
+        "title": {"type": "text", "analyzer": "ngram_analyzer"}
+      }
+    }
+  }
+}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,6 +31,6 @@ class SearchTestCase(unittest.TestCase):
     def test_search(self):
         self.app.elasticsearch.initialize_model(Movie)
 
-        query, total = self.app.elasticsearch.search(Movie, 'nightma', 1, 10)
+        query, total = self.app.elasticsearch.search(Movie, 'nightma', 0, 5)
         self.assertEqual(total, len(movie_titles))
         self.assertTrue(all(mt in [m.title for m in query] for mt in movie_titles))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+
+from api.factory import create_app
+from config import TestingConfig
+from db.models import Movie
+
+
+movie_titles = [
+    "a nightmare on elm street: the dream child",
+    "a nightmare on elm street 4: the dream master",
+]
+
+class ES_TestingConfig(TestingConfig):
+    ELASTICSEARCH_URL = os.getenv('ELASTICSEARCH_URL')
+
+
+class SearchTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = create_app(config=ES_TestingConfig)
+        self.client = self.app.test_client()
+
+        # Set up application context for the database
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app.elasticsearch.delete_index(Movie)
+
+    def test_search(self):
+        self.app.elasticsearch.initialize_model(Movie)
+
+        query, total = self.app.elasticsearch.search(Movie, 'nightmare', 1, 10)
+        self.assertGreaterEqual(total, len(movie_titles))
+        self.assertTrue(all(mt in [m.title for m in query] for mt in movie_titles))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,6 +31,6 @@ class SearchTestCase(unittest.TestCase):
     def test_search(self):
         self.app.elasticsearch.initialize_model(Movie)
 
-        query, total = self.app.elasticsearch.search(Movie, 'nightmare', 1, 10)
-        self.assertGreaterEqual(total, len(movie_titles))
+        query, total = self.app.elasticsearch.search(Movie, 'nightma', 1, 10)
+        self.assertEqual(total, len(movie_titles))
         self.assertTrue(all(mt in [m.title for m in query] for mt in movie_titles))


### PR DESCRIPTION
* enable full-text using Elasticsearch
* added search route movies: `api/search?query=<query>`
* added some basic tests
* lock package versions in Pipfile to compatible release (pipenv updates *all* dependencies in the lockfile if you install *any* new package. not quite sure if this is intended or a bug...)

for now, searching only works for movies but extending it to any other model is trivial. 

tests are separated from the other routes, so that they don't require ES to run. i had to update the ES version used by travis to make it work. unfortunately, this requires running the tests in a sudo-enabled VM (as opposed to a container-based environment) and slows them down significantly.

i was struggling a bit with properly integrating ES into our app. initializing everything in order was a bit tricky and as there a two separate but not independent modules, i had to try and avoid circular imports. my first intuition was putting the search logic in the ´db´ module, but i am not really sure if this is the most straightforward or elegant way of doing it.